### PR TITLE
Eliminate useless types

### DIFF
--- a/include/svm_constant_pool.h
+++ b/include/svm_constant_pool.h
@@ -37,20 +37,19 @@ typedef struct svm_class_cp_info svm_class_cp_info;
 #define SVM_METHOD_HANDLE_KIND_NEW_INVOKE_SPECIAL 8
 #define SVM_METHOD_HANDLE_KIND_INVOKE_INTERFACE 9
 
-#define SVM_CONSTANT_TAG_SIZE_UTF8 sizeof(svm_class_utf8)
-#define SVM_CONSTANT_TAG_SIZE_INTEGER sizeof(svm_class_int)
-#define SVM_CONSTANT_TAG_SIZE_FLOAT sizeof(svm_class_float)
-#define SVM_CONSTANT_TAG_SIZE_LONG sizeof(svm_class_long)
-#define SVM_CONSTANT_TAG_SIZE_DOUBLE sizeof(svm_class_double)
-#define SVM_CONSTANT_TAG_SIZE_CLASS sizeof(svm_class_class)
-#define SVM_CONSTANT_TAG_SIZE_STRING sizeof(svm_class_string)
-#define SVM_CONSTANT_TAG_SIZE_FIELD_REF sizeof(svm_class_field_ref)
-#define SVM_CONSTANT_TAG_SIZE_METHOD_REF sizeof(svm_class_method_ref)
-#define SVM_CONSTANT_TAG_SIZE_INTERFACE_METHOD_REF sizeof(svm_class_interface_method_ref)
-#define SVM_CONSTANT_TAG_SIZE_NAME_AND_TYPE sizeof(svm_class_name_and_type)
-#define SVM_CONSTANT_TAG_SIZE_METHOD_HANDLE sizeof(svm_class_method_handle)
-#define SVM_CONSTANT_TAG_SIZE_METHOD_TYPE sizeof(svm_class_method_type)
-#define SVM_CONSTANT_TAG_SIZE_INVOKE_DYNAMIC sizeof(svm_class_invoke_dynamic)
+#define SVM_CONSTANT_TAG_SIZE_UTF8 sizeof(uint8_t*)
+#define SVM_CONSTANT_TAG_SIZE_INTEGER 4
+#define SVM_CONSTANT_TAG_SIZE_FLOAT 4
+#define SVM_CONSTANT_TAG_SIZE_LONG 8
+#define SVM_CONSTANT_TAG_SIZE_DOUBLE 8
+#define SVM_CONSTANT_TAG_SIZE_CLASS 2
+#define SVM_CONSTANT_TAG_SIZE_STRING 2
+#define SVM_CONSTANT_TAG_SIZE_FIELD_REF 4
+#define SVM_CONSTANT_TAG_SIZE_METHOD_REF 4
+#define SVM_CONSTANT_TAG_SIZE_INTERFACE_METHOD_REF 4
+#define SVM_CONSTANT_TAG_SIZE_NAME_AND_TYPE 4
+#define SVM_CONSTANT_TAG_SIZE_METHOD_HANDLE 3
+#define SVM_CONSTANT_TAG_SIZE_METHOD_TYPE 2
 
 /**
  * An entry into the constant pool. The contense of info
@@ -70,98 +69,36 @@ struct svm_class_cp_info {
     void* further;
 };
 
-/** Constant info entry describing a class. */
 typedef struct {
-    uint16_t name_index;
-} svm_class_class;
+    uint16_t a;
+} svm_class_constant_scheme_16;
 
-/** Constant info entry describing a field reference. */
 typedef struct {
-    uint16_t class_index;
-    uint16_t name_and_type_index;
-} svm_class_field_ref;
+    uint16_t a;
+    uint16_t b;
+} svm_class_constant_scheme_16_16;
 
-/** Constant info entry describing a method reference. */
 typedef struct {
-    uint16_t class_index;
-    uint16_t name_and_type_index;
-} svm_class_method_ref;
+    uint32_t a;
+} svm_class_constant_scheme_32;
 
-/** Constant info entry describing a interface method reference. */
 typedef struct {
-    uint16_t class_index;
-    uint16_t name_and_type_index;
-} svm_class_interface_method_ref;
+    uint32_t a;
+    uint32_t b;
+} svm_class_constant_scheme_32_32;
 
-/** Constant info entry describing a string. */
 typedef struct {
-    uint16_t string_index;
-} svm_class_string;
+    uint8_t a;
+} svm_class_constant_scheme_8;
 
-/** Constant info entry describing an integer. */
 typedef struct {
-    uint32_t bytes;
-} svm_class_int;
-/** Constant info entry describing a float. */
-typedef struct {
-    uint32_t bytes;
-} svm_class_float;
+    uint8_t a;
+    uint16_t b;
+} svm_class_constant_scheme_8_16;
 
-/** Constant info entry describing a long. */
 typedef struct {
-    uint32_t low;
-    uint32_t high;
-} svm_class_long;
-
-/** Constant info entry describing a double. */
-typedef struct {
-    uint32_t low;
-    uint32_t high;
-} svm_class_double;
-
-/** Constant info entry describing a name and type. */
-typedef struct {
-    uint16_t name_index;
-    uint16_t descriptor_index;
-} svm_class_name_and_type;
-
-/** Constant info entry describing a UTF8 string. */
-typedef struct {
-    uint8_t* bytes;
-} svm_class_utf8;
-
-/** Constant info entry describing a method handle. */
-typedef struct {
-    uint8_t reference_kind;
-    uint16_t reference_index;
-} svm_class_method_handle;
-
-/** Constant info entry describing a method type. */
-typedef struct {
-    uint16_t descriptor_index;
-} svm_class_method_type;
-
-/** Constant info entry describing a dynamic. */
-typedef struct {
-    uint16_t bootstrap_method_attr_index;
-    uint16_t name_and_type_index;
-} svm_class_dynamic;
-
-/** Constant info entry describing the invocation of a dynamic. */
-typedef struct {
-    uint16_t bootstrap_method_attr_index;
-    uint16_t name_and_type_index;
-} svm_class_invoke_dynamic;
-
-/** Constant info entry describing a class module. */
-typedef struct {
-    uint16_t name_index;
-} svm_class_class_module;
-
-/** Constant info entry describing a class package. */
-typedef struct {
-    uint16_t name_index;
-} svm_class_class_package;
+    uint8_t* a;
+} svm_class_constant_scheme_8ptr;
 
 /** Get the size that the "payload" (info member)
  * is, in bytes. This will return the max on types that

--- a/src/libsvm/class.c
+++ b/src/libsvm/class.c
@@ -80,7 +80,7 @@ void svm_dump_class(svm_class* class) {
     for (int i = 0; i < class->constant_pool_count-1; i++) {
         uint8_t tag = class->constant_pool[i].tag;
 
-        log_trace("\t%d. %s", i+1, svm_constant_tag_as_string(tag));
+        log_trace("%d. %s", i+1, svm_constant_tag_as_string(tag));
         svm_class_print_constant_entry(tag, class->constant_pool[i].further, class->constant_pool);
     }
 }

--- a/src/libsvm/constant_pool.c
+++ b/src/libsvm/constant_pool.c
@@ -82,7 +82,7 @@ size_t svm_class_get_next_constant_entry_utf8(svm_class_cp_info* info, unsigned 
     uint16_t length = (src[offset] << 8) + src[offset+1];
     size_t track_offset = length;
     uint8_t* str = malloc(length * sizeof(uint8_t) + 1);
-    svm_class_utf8* typed_info = malloc(SVM_CONSTANT_TAG_SIZE_UTF8);
+    svm_class_constant_scheme_8ptr* typed_info = malloc(SVM_CONSTANT_TAG_SIZE_UTF8);
 
     if (typed_info == NULL) {
         log_fatal("Failed to allocatae memory for UTF8 typed info (%d): %s",
@@ -101,7 +101,7 @@ size_t svm_class_get_next_constant_entry_utf8(svm_class_cp_info* info, unsigned 
 
     str[length] = '\0';
 
-    typed_info->bytes = str;
+    typed_info->a = str;
 
     info->further = typed_info;
     info->tag = SVM_CONSTANT_TAG_UTF8;

--- a/src/libsvm/constant_pool_switch.c
+++ b/src/libsvm/constant_pool_switch.c
@@ -39,8 +39,6 @@ size_t svm_class_tag_constant_to_size(uint8_t tag) {
             return SVM_CONSTANT_TAG_SIZE_METHOD_HANDLE;
         case SVM_CONSTANT_TAG_METHOD_TYPE:
             return SVM_CONSTANT_TAG_SIZE_METHOD_TYPE;
-        case SVM_CONSTANT_TAG_INVOKE_DYNAMIC:
-            return SVM_CONSTANT_TAG_SIZE_INVOKE_DYNAMIC;
         default:
             // log_fatal("Unknown constant type when getting tag info length (%d, %04X).", tag, tag);
             log_fatal("Unknown constant pool tag (%d, 0x%02X).", tag, tag);
@@ -90,91 +88,91 @@ char* svm_constant_tag_as_string(uint8_t tag) {
     }
 }
 
-// TODO: VERY MUCH optimize for DRY.
+// TODO: Optimize for DRY.
 uint16_t svm_class_create_fixed_constant_entry(void* further, uint8_t tag, unsigned char* src, size_t offset) {
     switch (tag) {
         case SVM_CONSTANT_TAG_CLASS:
-            ((svm_class_class*)further)->name_index =
+            ((svm_class_constant_scheme_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
             return 2;
         case SVM_CONSTANT_TAG_FIELD_REF:
-            ((svm_class_field_ref*)further)->class_index =
+            ((svm_class_constant_scheme_16_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
-            ((svm_class_field_ref*)further)->name_and_type_index =
+            ((svm_class_constant_scheme_16_16*)further)->b =
                 (src[offset+2] << 8) + src[offset+3];
             return 4;
         case SVM_CONSTANT_TAG_METHOD_REF:
-            ((svm_class_field_ref*)further)->class_index =
+            ((svm_class_constant_scheme_16_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
-            ((svm_class_field_ref*)further)->name_and_type_index =
+            ((svm_class_constant_scheme_16_16*)further)->b =
                 (src[offset+2] << 8) + src[offset+3];
             return 4;
         case SVM_CONSTANT_TAG_INTERFACE_METHOD_REF:
-            ((svm_class_field_ref*)further)->class_index =
+            ((svm_class_constant_scheme_16_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
-            ((svm_class_field_ref*)further)->name_and_type_index =
+            ((svm_class_constant_scheme_16_16*)further)->b =
                 (src[offset+2] << 8) + src[offset+3];
             return 4;
         case SVM_CONSTANT_TAG_STRING:
-            ((svm_class_string*)further)->string_index =
+            ((svm_class_constant_scheme_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
             return 2;
         case SVM_CONSTANT_TAG_INTEGER:
-            ((svm_class_int*)further)->bytes =
+            ((svm_class_constant_scheme_32*)further)->a =
                 (src[offset] << 24) + (src[offset+1] << 16) +
                 (src[offset+2] << 8) + src[offset+3];
             return 4;
         case SVM_CONSTANT_TAG_FLOAT:
-            ((svm_class_float*)further)->bytes =
+            ((svm_class_constant_scheme_32*)further)->a =
                 (src[offset] << 24) + (src[offset+1] << 16) +
                 (src[offset+2] << 8) + src[offset+3];
             return 4;
         case SVM_CONSTANT_TAG_LONG:
-            ((svm_class_long*)further)->low =
+            ((svm_class_constant_scheme_32_32*)further)->a =
                 (src[offset] << 24) + (src[offset+1] << 16) +
                 (src[offset+2] << 8) + src[offset+3];
 
-            ((svm_class_long*)further)->high =
+            ((svm_class_constant_scheme_32_32*)further)->b =
                 (src[offset+4] << 24) + (src[offset+5] << 16) +
                 (src[offset+6] << 8) + src[offset+7];
             return 8;
         case SVM_CONSTANT_TAG_DOUBLE:
-            ((svm_class_double*)further)->low =
+            ((svm_class_constant_scheme_32_32*)further)->a =
                 (src[offset] << 24) + (src[offset+1] << 16) +
                 (src[offset+2] << 8) + src[offset+3];
 
-            ((svm_class_double*)further)->high =
+            ((svm_class_constant_scheme_32_32*)further)->b =
                 (src[offset+4] << 24) + (src[offset+5] << 16) +
                 (src[offset+6] << 8) + src[offset+7];
             return 8;
         case SVM_CONSTANT_TAG_NAME_AND_TYPE:
-            ((svm_class_name_and_type*)further)->name_index =
+            ((svm_class_constant_scheme_16_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
-            ((svm_class_name_and_type*)further)->descriptor_index =
+            ((svm_class_constant_scheme_16_16*)further)->b =
                 (src[offset+2] << 8) + src[offset+3];
             return 4;
         case SVM_CONSTANT_TAG_METHOD_HANDLE:
-            ((svm_class_method_handle*)further)->reference_kind =
+            ((svm_class_constant_scheme_8_16*)further)->a =
                 src[offset];
-            ((svm_class_method_handle*)further)->reference_index =
+            ((svm_class_constant_scheme_8_16*)further)->b =
                 (src[offset+1] << 8) + src[offset+2];
             return 3;
         case SVM_CONSTANT_TAG_METHOD_TYPE:
-            ((svm_class_method_type*)further)->descriptor_index =
+            ((svm_class_constant_scheme_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
             return 2;
         case SVM_CONSTANT_TAG_INVOKE_DYNAMIC:
-            ((svm_class_invoke_dynamic*)further)->bootstrap_method_attr_index =
+            ((svm_class_constant_scheme_16_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
-            ((svm_class_invoke_dynamic*)further)->name_and_type_index =
+            ((svm_class_constant_scheme_16_16*)further)->b =
                 (src[offset+2] << 8) + src[offset+3];
             return 4;
         case SVM_CONSTANT_TAG_CLASS_MODULE:
-            ((svm_class_class_module*)further)->name_index =
+            ((svm_class_constant_scheme_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
             return 2;
         case SVM_CONSTANT_TAG_CLASS_PACKAGE:
-            ((svm_class_class_package*)further)->name_index =
+            ((svm_class_constant_scheme_16*)further)->a =
                 (src[offset] << 8) + src[offset+1];
             return 2;
         default:
@@ -188,125 +186,128 @@ uint16_t svm_class_create_fixed_constant_entry(void* further, uint8_t tag, unsig
 }
 
 void svm_class_print_constant_entry(uint16_t tag, void* further, svm_class_cp_info* pool) {
+    // We may want to use this at some point to recursively
+    // figure out all the available information for a
+    // constant entry.
+    (void)pool;
+
     switch (tag) {
         case SVM_CONSTANT_TAG_CLASS: {
-            svm_class_class* typed_info = further;
+            svm_class_constant_scheme_16* typed_info = further;
 
             log_trace("-- Name index : %04X (%d)",
-                    typed_info->name_index, typed_info->name_index);
+                    typed_info->a, typed_info->a);
 
             break;
         }
         case SVM_CONSTANT_TAG_FIELD_REF: {
-            svm_class_field_ref* typed_info = further;
+            svm_class_constant_scheme_16_16* typed_info = further;
 
             log_trace("-- Class Index : %04X (%d)",
-                    typed_info->class_index, typed_info->class_index);
+                    typed_info->a, typed_info->a);
             log_trace("-- Name & Type Index : %04X (%d)",
-                    typed_info->name_and_type_index, typed_info->name_and_type_index);
+                    typed_info->b, typed_info->b);
 
             break;
         }
         case SVM_CONSTANT_TAG_METHOD_REF: {
-            svm_class_method_ref* typed_info = further;
+            svm_class_constant_scheme_16_16* typed_info = further;
 
             log_trace("-- Class Index : %04X (%d)",
-                    typed_info->class_index, typed_info->class_index);
+                    typed_info->a, typed_info->a);
             log_trace("-- Name & Type Index : %04X (%d)",
-                    typed_info->name_and_type_index, typed_info->name_and_type_index);
+                    typed_info->b, typed_info->b);
 
             break;
         }
         case SVM_CONSTANT_TAG_INTERFACE_METHOD_REF: {
-            svm_class_interface_method_ref* typed_info = further;
+            svm_class_constant_scheme_16_16* typed_info = further;
 
             log_trace("-- Class Index : %04X (%d)",
-                    typed_info->class_index, typed_info->class_index);
+                    typed_info->a, typed_info->a);
             log_trace("-- Name & Type Index : %04X (%d)",
-                    typed_info->name_and_type_index, typed_info->name_and_type_index);
+                    typed_info->b, typed_info->b);
 
             break;
         }
         case SVM_CONSTANT_TAG_STRING: {
-            svm_class_string* typed_info = further;
+            svm_class_constant_scheme_16* typed_info = further;
 
             log_trace("-- UTF8 Index : %04X (%d)",
-                    typed_info->string_index, typed_info->string_index);
+                    typed_info->a, typed_info->a);
 
             break;
         }
         case SVM_CONSTANT_TAG_INTEGER: {
-            svm_class_int* typed_info = further;
+            svm_class_constant_scheme_32* typed_info = further;
 
-            log_trace("-- Bytes : %08X", typed_info->bytes);
+            log_trace("-- Bytes : %08X", typed_info->a);
 
             break;
         }
         case SVM_CONSTANT_TAG_FLOAT: {
-            svm_class_float* typed_info = further;
+            svm_class_constant_scheme_32* typed_info = further;
 
-            log_trace("-- Bytes : %08X", typed_info->bytes);
+            log_trace("-- Bytes : %08X", typed_info->a);
 
             break;
         }
         case SVM_CONSTANT_TAG_LONG: {
             // Fuck. You. Mr. Long.
-            svm_class_long* typed_info = further;
+            svm_class_constant_scheme_32_32* typed_info = further;
 
-            log_trace("-- Low : %08X", typed_info->low);
-            log_trace("-- High : %08X", typed_info->high);
+            log_trace("-- Low : %08X", typed_info->a);
+            log_trace("-- High : %08X", typed_info->b);
 
             break;
         }
         case SVM_CONSTANT_TAG_DOUBLE: {
-            svm_class_double* typed_info = further;
+            svm_class_constant_scheme_32_32* typed_info = further;
 
-            log_trace("-- Low : %08X", typed_info->low);
-            log_trace("-- High : %08X", typed_info->high);
+            log_trace("-- Low : %08X", typed_info->a);
+            log_trace("-- High : %08X", typed_info->b);
 
             break;
         }
         case SVM_CONSTANT_TAG_NAME_AND_TYPE: {
-            svm_class_name_and_type* typed_info = further;
+            svm_class_constant_scheme_16_16* typed_info = further;
 
-            log_trace("-- Name Index : %d", typed_info->name_index);
-            log_trace("-- Descriptor Index : %d", typed_info->descriptor_index);
+            log_trace("-- Name Index : %d", typed_info->a);
+            log_trace("-- Descriptor Index : %d", typed_info->b);
 
             break;
         }
         case SVM_CONSTANT_TAG_UTF8: {
-            svm_class_utf8* typed_info = further;
+            svm_class_constant_scheme_8ptr* typed_info = further;
 
-            log_trace("-- String : %s", typed_info->bytes);
+            log_trace("-- String : %s", typed_info->a);
 
             break;
         }
         case SVM_CONSTANT_TAG_METHOD_HANDLE: {
-            svm_class_method_handle* typed_info = further;
-
             // TODO
 
             break;
         }
         case SVM_CONSTANT_TAG_METHOD_TYPE: {
-            svm_class_method_type* typed_info = further;
+            svm_class_constant_scheme_16* typed_info = further;
 
-            log_trace("-- Descriptor Index : %d", typed_info->descriptor_index);
+            log_trace("-- Descriptor Index : %d", typed_info->a);
 
             break;
         }
         case SVM_CONSTANT_TAG_CLASS_MODULE: {
-            svm_class_class_module* typed_info = further;
+            svm_class_constant_scheme_16* typed_info = further;
 
-            log_trace("-- Name Index : %d", typed_info->name_index);
+            log_trace("-- Name Index : %d", typed_info->a);
 
             break;
 
         }
         case SVM_CONSTANT_TAG_CLASS_PACKAGE: {
-            svm_class_class_package* typed_info = further;
+            svm_class_constant_scheme_16* typed_info = further;
 
-            log_trace("-- Name Index : %d", typed_info->name_index);
+            log_trace("-- Name Index : %d", typed_info->a);
 
         }
         default: {


### PR DESCRIPTION
Eliminate useless types. Everything now follows one of 6 schemas, instead of having many more types that are basically the same but with different member names.